### PR TITLE
Update dependencies to add pyyaml and fix name of jinja2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Simple JSON log parser for the Couchbase Operator 2.0.0 that presents them in hu
 ## Prerequisites
 
 * python
-* python-jinja2
+* jinja2
+* pyyaml
 
 ## Installation
 


### PR DESCRIPTION
I found that I needed pyyaml as well and I adjusted the name of
jinja2 to the name it uses when being pip installed.